### PR TITLE
changed back to 3.2.9 etcd and a small fix to the statefulset template.

### DIFF
--- a/vault-etcd/templates/statefulset.yaml
+++ b/vault-etcd/templates/statefulset.yaml
@@ -4,7 +4,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "vault-etcd.fullname" . }}
   labels:
-    app: {{ template "vault-etcd.name" .}}
+    app: {{ template "vault-etcd.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     component: "{{ .Release.Name }}-{{ .Values.component }}"
     heritage: {{ .Release.Service }}

--- a/vault-etcd/values.yaml
+++ b/vault-etcd/values.yaml
@@ -2,7 +2,7 @@ component: "etcd"
 
 image:
   source: "quay.io/coreos/etcd"
-  tag: "v3.0.17"
+  tag: "v3.2.9"
   pullPolicy: "Always"
 
 service:


### PR DESCRIPTION
**What this PR does / why we need it**: reverts default version of etcd, I will vet this for stability.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
