### PR TITLE
Client cert changes, allowing service dns name as acceptable host.

### DIFF
--- a/vault-etcd/templates/statefulset.yaml
+++ b/vault-etcd/templates/statefulset.yaml
@@ -59,8 +59,6 @@ spec:
           value: {{ .Values.service.tls.serverSecret.path | quote }}
         - name: CERTS_PEER_PATH
           value: {{ .Values.service.tls.peerSecret.path | quote }}
-        - name: CERTS_CLIENT_PATH
-          value: {{ .Values.service.tls.clientSecret.path | quote }}
         {{- end }}
         volumeMounts:
         - name: {{ .Values.storage.mount }}
@@ -79,9 +77,6 @@ spec:
           readOnly: true
         - name: peer-tls
           mountPath: {{ .Values.service.tls.peerSecret.path }}
-          readOnly: true
-        - name: client-tls
-          mountPath: {{ .Values.service.tls.clientSecret.path }}
           readOnly: true
         {{- end }}
         lifecycle:
@@ -104,11 +99,7 @@ spec:
       - name: peer-tls
         secret:
           secretName: {{ .Values.service.tls.peerSecret.name }}
-      - name: client-tls
-        secret:
-          secretName: {{ .Values.service.tls.clientSecret.name }}
       {{- end }}
-
   volumeClaimTemplates:
   - metadata:
         name: {{ .Values.storage.mount }}

--- a/vault-etcd/tls-generator/generate-certs.sh
+++ b/vault-etcd/tls-generator/generate-certs.sh
@@ -275,11 +275,12 @@ done
 # client certs
 inf "generating client certs..."
 inf "cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client client.json | cfssljson -bare client"
+CLIENT_HOSTNAMES="${GEN_HOSTS_CLIENT},${GEN_STATEFULSET_NAME},${GEN_STATEFULSET_NAME}.${GEN_NAMESPACE}"
 cfssl gencert \
     -ca=ca.pem \
     -ca-key=ca-key.pem \
     -config=ca-config.json \
-    -hostname=${GEN_HOSTS_CLIENT} \
+    -hostname=${CLIENT_HOSTNAMES} \
     -profile=client client.json | cfssljson -bare client
 
 

--- a/vault-etcd/values.yaml
+++ b/vault-etcd/values.yaml
@@ -1,3 +1,4 @@
+---
 rbac:
   create: true
   apiVersion: v1beta1


### PR DESCRIPTION
made changes to allow the service dns name to be an allowed host for the client certs. Also removed the requirements to load client certs into statefulset, too heavy handed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
