### PR TITLE
fixed client-server ticket for service use.

### DIFF
--- a/vault-etcd/tls-generator/generate-certs.sh
+++ b/vault-etcd/tls-generator/generate-certs.sh
@@ -253,6 +253,7 @@ fi
 # server certs
 inf "generating server certs..."
 inf "cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client server.json | cfssljson -bare server"
+SERVER_HOSTNAMES="${GEN_HOSTS_SERVER},${GEN_STATEFULSET_NAME},${GEN_STATEFULSET_NAME}.${GEN_NAMESPACE}"
 cfssl gencert \
     -ca=ca.pem \
     -ca-key=ca-key.pem \
@@ -264,11 +265,12 @@ cfssl gencert \
 for ((i = 0; i < GEN_CLUSTER_SIZE; i++)); do
     inf "generating peer cert: ${GEN_STATEFULSET_NAME}-${i} ..."
     inf "cfssl gencert -ca=ca.pem -ca-key=ca-key.pem -config=ca-config.json -profile=client ${GEN_STATEFULSET_NAME}-${i}.json | cfssljson -bare ${GEN_STATEFULSET_NAME}-${i}"
+    PEER_HOSTNAMES="${GEN_STATEFULSET_NAME}-${i},${GEN_STATEFULSET_NAME}-${i}.${GEN_STATEFULSET_NAME},${GEN_STATEFULSET_NAME},${GEN_STATEFULSET_NAME}.${GEN_NAMESPACE},127.0.0.1"
     cfssl gencert \
         -ca=ca.pem \
         -ca-key=ca-key.pem \
         -config=ca-config.json \
-        -hostname="${GEN_STATEFULSET_NAME}-${i}","${GEN_STATEFULSET_NAME}-${i}.${GEN_STATEFULSET_NAME}","127.0.0.1" \
+        -hostname=${PEER_HOSTNAMES} \
         -profile=client ${GEN_STATEFULSET_NAME}-${i}.json | cfssljson -bare ${GEN_STATEFULSET_NAME}-${i}
 done
 


### PR DESCRIPTION
Fixes issue where client cert is used from another namespace via service calls. The service call itself needs to be in a cert with that particular hostname <statefulset>.<namespace> also.



**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
